### PR TITLE
readline import fix

### DIFF
--- a/rlrepl.c
+++ b/rlrepl.c
@@ -1,6 +1,6 @@
 #include <janet.h>
-#include <readline.h>
-#include <history.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 
 static char *longest_common_prefix(char **strs, int n) {
   int shortest_len = -1;


### PR DESCRIPTION
GNU readline uses readline/readline.h as default header path (https://tiswww.case.edu/php/chet/readline/readline.html).

I'm not certain about other linux distributions, but Archlinux package for readline doesn't define additional pkgconf include path (readline.h and history.h are located in /usr/lib/include/readline)