### PR TITLE
fixed use of deprecated file/popen

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -16,6 +16,7 @@
   (def proc (os/spawn args :pe env))
   (ev/close (streams 1))
   (def text (string/trim (ev/read (streams 0) :all)))
+  (def exit_code (os/proc-wait proc))
   {:exit_code exit_code :text text})
 
 (defn pkg-config [& what]

--- a/project.janet
+++ b/project.janet
@@ -9,20 +9,24 @@
   :name "rlrepl"
   :source ["rlrepl.janet"])
 
-(defn pkg-config [what]
-  (def f (file/popen (string "pkg-config " what)))
-  (def v (->>
-           (file/read f :all)
-           (string/trim)
-           (string/split " ")))
-  (unless (zero? (file/close f))
+(defn exec_get_string_and_exit_code [args]
+  (def env (os/environ))
+  (def streams (os/pipe))
+  (put env :out (streams 1))
+  (def exit_code (os/execute args :pe env))
+  (ev/close (streams 1))
+  {:exit_code exit_code :text (string/trim (ev/read (streams 0) :all))})
+
+(defn pkg-config [& what]
+  (def result (exec_get_string_and_exit_code ["pkg-config" ;what]))
+  (unless (zero? (result :exit_code))
     (error "pkg-config failed!"))
-  v)
+  (string/split " " (result :text)))
 
 (declare-native
   :name "_rlrepl"
-  :cflags (pkg-config "readline --cflags")
-  :lflags (pkg-config "readline --libs")
+  :cflags (pkg-config "readline" "--cflags")
+  :lflags (pkg-config "readline" "--libs")
   :source ["rlrepl.c"])
 
 (declare-source

--- a/project.janet
+++ b/project.janet
@@ -13,9 +13,10 @@
   (def env (os/environ))
   (def streams (os/pipe))
   (put env :out (streams 1))
-  (def exit_code (os/execute args :pe env))
+  (def proc (os/spawn args :pe env))
   (ev/close (streams 1))
-  {:exit_code exit_code :text (string/trim (ev/read (streams 0) :all))})
+  (def text (string/trim (ev/read (streams 0) :all)))
+  {:exit_code exit_code :text text})
 
 (defn pkg-config [& what]
   (def result (exec_get_string_and_exit_code ["pkg-config" ;what]))

--- a/project.janet
+++ b/project.janet
@@ -9,19 +9,19 @@
   :name "rlrepl"
   :source ["rlrepl.janet"])
 
-(defn exec_get_string_and_exit_code [args]
+(defn exec-get-string-and-exit-code [args]
   (def env (os/environ))
   (def streams (os/pipe))
   (put env :out (streams 1))
   (def proc (os/spawn args :pe env))
   (ev/close (streams 1))
   (def text (string/trim (ev/read (streams 0) :all)))
-  (def exit_code (os/proc-wait proc))
-  {:exit_code exit_code :text text})
+  (def exit-code (os/proc-wait proc))
+  {:exit-code exit-code :text text})
 
 (defn pkg-config [& what]
-  (def result (exec_get_string_and_exit_code ["pkg-config" ;what]))
-  (unless (zero? (result :exit_code))
+  (def result (exec-get-string-and-exit-code ["pkg-config" ;what]))
+  (unless (zero? (result :exit-code))
     (error "pkg-config failed!"))
   (string/split " " (result :text)))
 


### PR DESCRIPTION
project.janet was broken due to file/popen being deprecated, should be fixed by this.  
I'm not sure if it's the best way to solve it, but it seems to work fine.